### PR TITLE
feat: getFederatedEntity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -401,26 +401,24 @@ export function createMercuriusTestClient(
     keys: Record<string, string | number>
     typeQuery: string
   }) => {
-    let stringifiedKeys: string[] = []
-
-    for (const key in keys) {
-      const value = typeof keys[key] === 'number' ? keys[key] : `"${keys[key]}"`
-      stringifiedKeys.push(`${key}: ${value}`)
-    }
-
     try {
-      const result = await query(`
-      query {
-          _entities(representations: [{ __typename: "${typename}", ${stringifiedKeys.join(
-        ', '
-      )} }]) {
+      const result = await query(
+        `
+      query Entities($representations: [_Any!]!) {
+          _entities(representations: $representations) {
             __typename
             ... on ${typename} {
               ${typeQuery}
             }
           }
         }
-    `)
+    `,
+        {
+          variables: {
+            representations: [{ __typename: typename, ...keys }],
+          },
+        }
+      )
 
       return result.data._entities[0]
     } catch (err) {

--- a/test/federated-entity.test.ts
+++ b/test/federated-entity.test.ts
@@ -1,0 +1,191 @@
+import { fastify } from 'fastify'
+import mercurius from 'mercurius'
+import tap from 'tap'
+
+import { createMercuriusTestClient } from '../src'
+
+tap.test('returns single-key federated entity', async (t) => {
+  const schema = `
+    type Post @key(fields: "id") {
+      id: ID! @external
+      description: String!
+    }
+  
+    extend type User @key(fields: "id") {
+      id: ID! @external
+      posts: [Post!]!
+    }
+  `
+
+  const app = fastify()
+  app.register(mercurius, {
+    schema,
+    resolvers: {
+      User: {
+        posts: () => [{ id: 'post-id', description: 'Post description' }],
+      },
+    },
+    federationMetadata: true,
+  })
+
+  const client = createMercuriusTestClient(app)
+
+  t.plan(1)
+
+  t.same(
+    await client.getFederatedEntity({
+      typename: 'User',
+      keys: { id: 'user1' },
+      typeQuery: `
+        id
+        posts {
+          id
+          description
+        }`,
+    }),
+    {
+      __typename: 'User',
+      id: 'user1',
+      posts: [
+        {
+          id: 'post-id',
+          description: 'Post description',
+        },
+      ],
+    }
+  )
+})
+
+tap.test('returns multi-key federated entity', async (t) => {
+  const schema = `
+      type ProductCategory {
+        id: ID!
+        name: String!
+      }
+    
+      extend type Product @key(fields: "sku") @key(fields: "upc") {
+        upc: String! @external
+        sku: Int! @external
+        category: ProductCategory
+      }
+    `
+
+  const app = fastify()
+  app.register(mercurius, {
+    schema,
+    resolvers: {
+      Product: {
+        category: () => ({ id: 'product-category', name: 'Stub category' }),
+      },
+    },
+    federationMetadata: true,
+  })
+
+  const client = createMercuriusTestClient(app)
+
+  t.plan(1)
+
+  t.same(
+    await client.getFederatedEntity({
+      typename: 'Product',
+      keys: { sku: 1, upc: 'upc' },
+      typeQuery: `
+          upc
+          sku
+          category {
+            id
+            name
+          }`,
+    }),
+    {
+      __typename: 'Product',
+      upc: 'upc',
+      sku: 1,
+      category: {
+        id: 'product-category',
+        name: 'Stub category',
+      },
+    }
+  )
+})
+
+tap.test('throws if service is not federated', async (t) => {
+  const schema = `
+    type Post @key(fields: "id") {
+      id: ID! @external
+      description: String!
+    }
+  
+    extend type User @key(fields: "id") {
+      id: ID! @external
+      posts: [Post!]!
+    }
+  `
+
+  const app = fastify()
+  app.register(mercurius, {
+    schema,
+    resolvers: {
+      User: {
+        posts: () => [{ id: 'post-id', description: 'Post description' }],
+      },
+    },
+    federationMetadata: false,
+  })
+
+  const client = createMercuriusTestClient(app)
+
+  t.plan(1)
+
+  t.rejects(
+    client.getFederatedEntity({
+      typename: 'User',
+      keys: { id: 'user1' },
+      typeQuery: `
+        id
+        posts {
+          id
+          description
+        }`,
+    }),
+    Error('Service is not federated')
+  )
+})
+
+tap.test('throws if entity is not federated', async (t) => {
+  const schema = `
+      type Post @key(fields: "id") {
+        id: ID! @external
+        description: String!
+      }
+    
+      extend type User @key(fields: "id") {
+        id: ID! @external
+        posts: [Post!]!
+      }
+    `
+
+  const app = fastify()
+  app.register(mercurius, {
+    schema,
+    resolvers: {
+      User: {
+        posts: () => [{ id: 'post-id', description: 'Post description' }],
+      },
+    },
+    federationMetadata: true,
+  })
+
+  const client = createMercuriusTestClient(app)
+
+  t.plan(1)
+
+  t.rejects(
+    client.getFederatedEntity({
+      typename: 'NotFederated',
+      keys: { id: 'not-important' },
+      typeQuery: `
+          __typename`,
+    })
+  )
+})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -282,7 +282,7 @@ tap.test('cookies', async (t) => {
       },
     }
   )
-  t.deepEqual(resp6, [{ data: { cookie: 'y' } }, { data: { cookie: 'y' } }])
+  t.same(resp6, [{ data: { cookie: 'y' } }, { data: { cookie: 'y' } }])
 })
 
 tap.test('headers', async (t) => {
@@ -381,7 +381,7 @@ tap.test('headers', async (t) => {
       },
     }
   )
-  t.deepEqual(resp6, [{ data: { header: 'y' } }, { data: { header: 'y' } }])
+  t.same(resp6, [{ data: { header: 'y' } }, { data: { header: 'y' } }])
 })
 
 tap.test('detects mercurius is not registered', (t) => {


### PR DESCRIPTION
This PR adds `getFederatedEntity` function to the client. The purpose is to make it easier to test federated service integration with the gateway (e.g extending an entity in a service that belongs to some other service). This function is a wrapper around `_entities` query which has a bit cumbersome API, which was the spark for this PR.

Closes #2 